### PR TITLE
Check for web-worker existence

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -10,13 +10,15 @@ define(function () {
 
 			var url = req.toUrl(name);
 
-			if (window.Worker) {
-				onLoad(new Worker(url));
-			} else {
-				req(["worker-fake"], function () {
+			req([url], function (resp) {
+				if (window.Worker) {
 					onLoad(new Worker(url));
-				});
-			}
+				} else {
+					req(["worker-fake"], function () {
+						onLoad(new Worker(url));
+					});
+				}
+			});
 		}
 	};
 });


### PR DESCRIPTION
In Chrome 49 console - if my-web-worker.js is missing / wrong path. Loader fails silently. 

Firefox console shows correct 404.

This edit will throw typical requirejs script not found.
